### PR TITLE
Katie updates

### DIFF
--- a/printer_build_schema.json
+++ b/printer_build_schema.json
@@ -654,15 +654,15 @@
       ],
       "propertyOrder": 6
     },
-    "openjzFile": {
+    "buildFile": {
       "title": "Build File",
-      "description": "Upload the build file (*.openjz)",
+      "description": "Upload the build file (e.g. *.openjz)",
       "$ref": "#/definitions/fileUpload",
       "propertyOrder": 11
     },
-    "eosReportFile": {
-      "title": "EOS Report",
-      "description": "Upload the EOS job quality report (PDF)",
+    "reportFile": {
+      "title": "Build Report File",
+      "description": "Upload e.g. the EOS job quality report (PDF)",
       "$ref": "#/definitions/fileUpload",
       "propertyOrder": 12
     },

--- a/printer_build_schema.json
+++ b/printer_build_schema.json
@@ -163,57 +163,6 @@
             "grid_break": true,
             "hidden": true
           }
-        },
-        "relatedIdentifiers": {
-          "type": "array",
-          "title": "Related Identifiers",
-          "propertyOrder": 7,
-          "readonly": true,
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "properties": {
-              "relatedIdentifier": {
-                "type": "string",
-                "title": "Related Identifier",
-                "propertyOrder": 1,
-                "readonly": true,
-                "watch": {
-                  "powderId": "root.rawPowderID"
-                },
-                "template": "/api/v1/entry/{{powderId}}"
-              },
-              "relatedIdentifierType": {
-                "type": "string",
-                "propertyOrder": 2,
-                "readonly": true,
-                "enum": [
-                  "URL",
-                  "IGSN",
-                  "DOI",
-                  "Other"
-                ],
-                "default": "URL"
-              },
-              "relationType": {
-                "type": "string",
-                "propertyOrder": 3,
-                "readonly": true,
-                "default": "HasMetadata"
-              },
-              "relatedMetadataScheme": {
-                "type": "string",
-                "propertyOrder": 4,
-                "readonly": true,
-                "default": "/api/v1/form/663e6d21b18fa1c426e939ab/schema"
-              }
-            }
-          },
-          "options": {
-            "grid_columns": 12,
-            "grid_break": true,
-            "hidden": true
-          }
         }
       }
     },
@@ -484,10 +433,13 @@
       "propertyOrder": 2
     },
     "rawPowderID": {
-      "title": "Raw Powder",
+      "title": "Raw Powders",
       "description": "Reference to a 'Raw Powder Details' entry",
-      "type": "string",
-      "enumSource": "girder.formId:663e6d21b18fa1c426e939ab",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enumSource": "girder.formId:663e6d21b18fa1c426e939ab"
+      },
       "propertyOrder": 3
     },
     "buildGeometries": {

--- a/raw_powder_schema.json
+++ b/raw_powder_schema.json
@@ -127,47 +127,85 @@
             "type": "object",
             "format": "grid",
             "properties": {
+                "tested": {
+                    "title": "Tested?",
+                    "description": "Check if particle size distribution and virgin powder percentage are known",
+                    "type": "boolean",
+                    "format": "checkbox",
+                    "default": true,
+                    "propertyOrder": 0
+                },
                 "minSize": {
                     "title": "Min Particle Size (microns)",
                     "type": "number",
                     "minimum": 10,
                     "maximum": 100,
-                    "propertyOrder": 0
+                    "propertyOrder": 1,
+                    "options": {
+                        "dependencies": {
+                            "tested": true
+                        }
+                    }
                 },
                 "tenthPercentileSize": {
                     "title": "D10 Particle Size (microns)",
                     "type": "number",
                     "minimum": 10,
                     "maximum": 100,
-                    "propertyOrder": 1
+                    "propertyOrder": 2,
+                    "options": {
+                        "dependencies": {
+                            "tested": true
+                        }
+                    }
                 },
                 "fiftiethPercentileSize": {
                     "title": "D50 Particle Size (microns)",
                     "type": "number",
                     "minimum": 10,
                     "maximum": 100,
-                    "propertyOrder": 2
+                    "propertyOrder": 3,
+                    "options": {
+                        "dependencies": {
+                            "tested": true
+                        }
+                    }
                 },
                 "ninetiethPercentileSize": {
                     "title": "D90 Particle Size (microns)",
                     "type": "number",
                     "minimum": 10,
                     "maximum": 100,
-                    "propertyOrder": 3
+                    "propertyOrder": 4,
+                    "options": {
+                        "dependencies": {
+                            "tested": true
+                        }
+                    }
                 },
                 "maxSize": {
                     "title": "Max Particle Size (microns)",
                     "type": "number",
                     "minimum": 10,
                     "maximum": 100,
-                    "propertyOrder": 4
+                    "propertyOrder": 5,
+                    "options": {
+                        "dependencies": {
+                            "tested": true
+                        }
+                    }
                 },
                 "virginPercent": {
                     "title": "Virgin Powder %",
                     "type": "number",
                     "minimum": 0,
                     "maximum": 100,
-                    "propertyOrder": 5
+                    "propertyOrder": 6,
+                    "options": {
+                        "dependencies": {
+                            "tested": true
+                        }
+                    }
                 }
             },
             "propertyOrder": 8

--- a/raw_powder_schema.json
+++ b/raw_powder_schema.json
@@ -24,7 +24,7 @@
             "type": "string",
             "enum": [
                 "Ti-6Al-4V",
-                "IN718"
+                "alloy718"
             ],
             "propertyOrder": 1
         },


### PR DESCRIPTION
This pull request updates the printer build and raw powder schema JSON files to improve data structure, naming consistency, and conditional logic for powder testing fields. The most significant changes include restructuring how raw powders are referenced, renaming several file fields for clarity, and adding conditional dependencies for particle size and virgin percentage fields based on a new "tested" checkbox.

Schema structure and data relationships:

* Changed the `rawPowderID` field in `printer_build_schema.json` to an array of strings, allowing multiple raw powders to be referenced instead of just one.
* Removed the `relatedIdentifiers` field from `printer_build_schema.json`, simplifying the schema and removing a hidden, readonly array of related identifier objects.

Field naming and clarity:

* Renamed `openjzFile` to `buildFile` and `eosReportFile` to `reportFile` in `printer_build_schema.json` for clearer and more generic file field names and descriptions.

Conditional logic and options:

* In `raw_powder_schema.json`, added a "Tested?" checkbox (`tested` field) to the particle size distribution group. All particle size and virgin percentage fields now depend on this checkbox being checked, improving data entry logic and UI clarity.

Material naming consistency:

* Updated the material enum in `raw_powder_schema.json` from `"IN718"` to `"alloy718"` for consistency with naming conventions.