### PR TITLE
Add Heat Treatment Record Form Schema

### DIFF
--- a/heat_treatment.js
+++ b/heat_treatment.js
@@ -1,0 +1,114 @@
+window.JSONEditor.defaults.callbacks.autocomplete = {
+    'search_deposition': function (editor, input) {
+        if (input.length < 3) {
+            return [];
+        }
+
+        return restRequest({
+            url: 'deposition',
+            method: 'GET',
+            data: {
+                q: input,
+                limit: 10
+            }
+        })
+    },
+    'render_deposition': function (editor, result, props) {
+        try {
+          const localId = result.metadata.alternateIdentifiers.find(
+              (id) => id.alternateIdentifierType.toLowerCase() === 'local'
+          );
+          return `<li ${props}> ${result.igsn} (localId: ${localId.alternateIdentifier})</li>`;
+        } catch (e) {
+          return `<li ${props}> ${result.igsn} (title: ${result.metadata.titles[0]['title']})</li>`;
+        }
+    },
+    'get_deposition_value': function (editor, result) {
+        try {
+          const localId = result.metadata.alternateIdentifiers.find(
+            (id) => id.alternateIdentifierType.toLowerCase() === 'local'
+          );
+          return `${result.igsn}`;
+        } catch (e) {
+          return `${result.igsn}`;
+        }
+    }
+};
+
+Handlebars.registerHelper('formatHTParamsShort', function (stress_relief, heat_treatment) {
+    if (!stress_relief) {
+        return '';
+    }
+    
+    // Build SR params array - include units/labels with values
+    const srPartsArray = [];
+    
+    if (stress_relief.time_hr) srPartsArray.push(`${stress_relief.time_hr}hr`);
+    if (stress_relief.temperature_C) srPartsArray.push(`${stress_relief.temperature_C}C`);
+    if (stress_relief.ramp_up_C_per_min) srPartsArray.push(`${stress_relief.ramp_up_C_per_min}rpm`);
+    if (stress_relief.cool) srPartsArray.push(`${stress_relief.cool.substring(0, 1).toUpperCase()}${stress_relief.cool.substring(1).toLowerCase()}`);
+    if (stress_relief.environment) srPartsArray.push(`${stress_relief.environment}`);
+    
+    const srParams = srPartsArray.join('-');
+    
+    // Heat Treatment parameters
+    let htParams = '';
+    let hasHIP = false;
+    
+    if (heat_treatment && Array.isArray(heat_treatment) && heat_treatment.length > 0) {
+        const htPartsArray = heat_treatment.map(ht => {
+            // Check if HIP was applied
+            if (ht.HIP && typeof ht.HIP === 'object' && ht.HIP.pressure_MPa) {
+                hasHIP = true;
+            }
+            
+            // Build HT params array - include units/labels with values
+            const htSubArray = [];
+            if (ht.time_hr) htSubArray.push(`${ht.time_hr}hr`);
+            if (ht.temperature_C) htSubArray.push(`${ht.temperature_C}C`);
+            if (ht.ramp_up_C_per_min) htSubArray.push(`${ht.ramp_up_C_per_min}rpm`);
+            if (ht.cool) htSubArray.push(`${ht.cool.substring(0, 1).toUpperCase()}${ht.cool.substring(1).toLowerCase()}`);
+            if (ht.environment) htSubArray.push(`${ht.environment}`);
+            
+            return htSubArray.join('-');
+        });
+        
+        htParams = htPartsArray.join('_');
+    }
+    
+    // Final format: HT_[SR params]_SR[_HT params][_hipped]
+    let result = `HT_${srParams}_SR`;
+    
+    if (htParams) {
+        result += `_${htParams}`;
+    }
+    
+    if (hasHIP) {
+        result += `_hipped`;
+    }
+    
+    return result;
+});
+
+// Validator to prevent changing HeattreatmentID to a completely different value
+JSONEditor.defaults.custom_validators.push(function (schema, value, path) {
+  // Only validate HeattreatmentID field
+  if (!schema.title || schema.title !== "Heat Treatment ID") {
+    return [];
+  }
+
+  if (!value) {
+    return [];
+  }
+
+  // Check if value starts with HT_ format
+  if (typeof value === 'string' && !value.startsWith('HT_')) {
+    // If someone tries to set it to something that doesn't look like the format, reject it
+    return [{
+      path: path,
+      message: `Invalid Heat Treatment ID format. Format must be: HT_[parameters]_SR`
+    }];
+  }
+
+  return [];
+});

--- a/heat_treatment.js
+++ b/heat_treatment.js
@@ -46,7 +46,7 @@ Handlebars.registerHelper('formatHTParamsShort', function (stress_relief, heat_t
     if (stress_relief.time_hr) srPartsArray.push(`${stress_relief.time_hr}hr`);
     if (stress_relief.temperature_C) srPartsArray.push(`${stress_relief.temperature_C}C`);
     if (stress_relief.ramp_up_C_per_min) srPartsArray.push(`${stress_relief.ramp_up_C_per_min}rpm`);
-    if (stress_relief.cool) srPartsArray.push(`${stress_relief.cool.substring(0, 1).toUpperCase()}${stress_relief.cool.substring(1).toLowerCase()}`);
+    if (stress_relief.cooling_method) srPartsArray.push(`${stress_relief.cooling_method.substring(0, 1).toUpperCase()}${stress_relief.cooling_method.substring(1).toLowerCase()}`);
     if (stress_relief.environment) srPartsArray.push(`${stress_relief.environment}`);
     
     const srParams = srPartsArray.join('-');
@@ -67,7 +67,7 @@ Handlebars.registerHelper('formatHTParamsShort', function (stress_relief, heat_t
             if (ht.time_hr) htSubArray.push(`${ht.time_hr}hr`);
             if (ht.temperature_C) htSubArray.push(`${ht.temperature_C}C`);
             if (ht.ramp_up_C_per_min) htSubArray.push(`${ht.ramp_up_C_per_min}rpm`);
-            if (ht.cool) htSubArray.push(`${ht.cool.substring(0, 1).toUpperCase()}${ht.cool.substring(1).toLowerCase()}`);
+            if (ht.cooling_method) htSubArray.push(`${ht.cooling_method.substring(0, 1).toUpperCase()}${ht.cooling_method.substring(1).toLowerCase()}`);
             if (ht.environment) htSubArray.push(`${ht.environment}`);
             
             return htSubArray.join('-');

--- a/heat_treatment.json
+++ b/heat_treatment.json
@@ -1,0 +1,199 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HT_Sample Heat Treatment Record",
+  "description": "Schema for the Heat Treatment sheet of the ProcessingParam HT Sample spreadsheet.",
+  "type": "object",
+  "required": [
+    "lookup",
+    "stress_relief",
+    "heat_treatment"
+  ],
+  "properties": {
+    "HeattreatmentID": {
+      "title": "Heat Treatment ID",
+      "description": "Automatically generated, unique identifier for this heat treatment record",
+      "notes": "This ID is auto-generated based on heat treatment parameters. You can modify it to correct missing values, but cannot change it to a completely different ID.",
+      "type": "string",
+      "template": "{{formatHTParamsShort stress_relief heat_treatment}}",
+      "readOnly": false,
+      "propertyOrder": 0,
+      "watch": {
+        "stress_relief": "root.stress_relief",
+        "heat_treatment": "root.heat_treatment"
+      },
+      "options": {
+        "grid_columns": 12
+      }
+    },
+    "lookup": {
+      "type": "array",
+      "title": "IGSNs",
+      "description": "Select one or more IGSNs",
+      "notes": "Search and select one or more IGSN identifiers associated with this sample. At least one IGSN must be provided.",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "format": "autocomplete",
+        "options": {
+          "autocomplete": {
+            "search": "search_deposition",
+            "renderResult": "render_deposition",
+            "getResultValue": "get_deposition_value",
+            "autoSelect": true,
+            "debounceTime": 500
+          }
+        }
+      },
+      "propertyOrder": 1
+    },
+    "stress_relief": {
+      "type": "object",
+      "title": "Stress Relief",
+      "description": "Stress relief heat treatment parameters",
+      "notes": "Stress relief is a mandatory step. Record the thermal cycle used to reduce residual stresses after fabrication.",
+      "format": "grid-strict",
+      "propertyOrder": 2,
+      "required": [
+        "time_hr",
+        "temperature_C",
+        "ramp_up_C_per_min",
+        "cool",
+        "environment"
+      ],
+      "properties": {
+        "time_hr": {
+          "type": "number",
+          "title": "Time (hr)",
+          "description": "Duration of stress relief in hours",
+          "examples": [2],
+          "options": { "grid_columns": 4 },
+          "propertyOrder": 0
+        },
+        "temperature_C": {
+          "type": "number",
+          "title": "Temperature (°C)",
+          "description": "Stress relief temperature in degrees Celsius",
+          "examples": [593],
+          "options": { "grid_columns": 4 },
+          "propertyOrder": 1
+        },
+        "ramp_up_C_per_min": {
+          "type": "number",
+          "title": "Ramp Up (°C/min)",
+          "description": "Ramp-up rate in degrees Celsius per minute",
+          "examples": [5],
+          "options": { "grid_columns": 4 },
+          "propertyOrder": 2
+        },
+        "cool": {
+          "type": "string",
+          "title": "Cooling Method",
+          "description": "Cooling method after hold",
+          "examples": ["Furnace"],
+          "options": { "grid_columns": 4 },
+          "propertyOrder": 3
+        },
+        "environment": {
+          "type": "string",
+          "title": "Environment",
+          "description": "Atmospheric environment during stress relief",
+          "examples": ["Ar"],
+          "options": { "grid_columns": 4 },
+          "propertyOrder": 4
+        }
+      }
+    },
+    "heat_treatment": {
+      "type": "array",
+      "title": "Heat Treatment",
+      "description": "One or more heat treatment entries for this sample",
+      "notes": "Add one or more heat treatment cycles applied to this sample after stress relief. Each entry represents a distinct thermal cycle. Leave this section empty if no further heat treatment was performed.",
+      "format": "tabs",
+      "options": {
+        "collapsed": false
+      },
+      "propertyOrder": 3,
+      "items": {
+        "type": "object",
+        "title": "Heat Treatment Entry",
+        "format": "grid-strict",
+        "required": [
+          "time_hr",
+          "temperature_C",
+          "ramp_up_C_per_min",
+          "cool",
+          "environment"
+        ],
+        "properties": {
+          "time_hr": {
+            "type": "number",
+            "title": "Time (hr)",
+            "description": "Duration of heat treatment in hours",
+            "examples": [2],
+            "options": { "grid_columns": 4 },
+            "propertyOrder": 0
+          },
+          "temperature_C": {
+            "type": "number",
+            "title": "Temperature (°C)",
+            "description": "Heat treatment temperature in degrees Celsius",
+            "examples": [820],
+            "options": { "grid_columns": 4 },
+            "propertyOrder": 1
+          },
+          "ramp_up_C_per_min": {
+            "type": "number",
+            "title": "Ramp Up (°C/min)",
+            "description": "Ramp-up rate in degrees Celsius per minute",
+            "examples": [5],
+            "options": { "grid_columns": 4 },
+            "propertyOrder": 2
+          },
+          "cool": {
+            "type": "string",
+            "title": "Cooling Method",
+            "description": "Cooling method after hold",
+            "examples": ["Furnace"],
+            "options": { "grid_columns": 4 },
+            "propertyOrder": 3
+          },
+          "environment": {
+            "type": "string",
+            "title": "Environment",
+            "description": "Atmospheric environment during heat treatment",
+            "examples": ["Ar"],
+            "options": { "grid_columns": 4 },
+            "propertyOrder": 4
+          },
+          "HIP": {
+            "title": "HIP",
+            "description": "Hot Isostatic Pressing — indicate whether the sample was HIPed",
+            "notes": "Select 'HIPed' if Hot Isostatic Pressing was applied. Select 'Not HIPed' if HIP was not performed.",
+            "options": { "grid_columns": 4 },
+            "propertyOrder": 5,
+            "oneOf": [
+              {
+                "title": "Not HIPed",
+                "type": "null"
+              },
+              {
+                "title": "HIPed",
+                "type": "object",
+                "required": ["pressure_MPa"],
+                "properties": {
+                  "pressure_MPa": {
+                    "type": "number",
+                    "title": "Pressure (MPa)",
+                    "description": "HIP pressure in megapascals",
+                    "examples": [100],
+                    "options": { "grid_columns": 4 }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/heat_treatment.json
+++ b/heat_treatment.json
@@ -1,15 +1,65 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "HT_Sample Heat Treatment Record",
-  "description": "Schema for the Heat Treatment sheet of the ProcessingParam HT Sample spreadsheet.",
+  "title": "Sample Heat Treatment Record",
+  "description": "Schema for recording heat treatment processes including stress relief and subsequent thermal cycles.",
   "type": "object",
   "required": [
     "lookup",
     "stress_relief",
     "heat_treatment"
   ],
+  "definitions": {
+    "heating_process": {
+      "type": "object",
+      "format": "grid-strict",
+      "required": [
+        "time_hr",
+        "temperature_C",
+        "ramp_up_C_per_min",
+        "cooling_method",
+        "environment"
+      ],
+      "properties": {
+        "time_hr": {
+          "type": "number",
+          "title": "Time (hr)",
+          "description": "Duration of heating process in hours",
+          "options": { "grid_columns": 4 },
+          "propertyOrder": 0
+        },
+        "temperature_C": {
+          "type": "number",
+          "title": "Temperature (°C)",
+          "description": "Heating temperature in degrees Celsius",
+          "options": { "grid_columns": 4 },
+          "propertyOrder": 1
+        },
+        "ramp_up_C_per_min": {
+          "type": "number",
+          "title": "Ramp Up (°C/min)",
+          "description": "Ramp-up rate in degrees Celsius per minute",
+          "options": { "grid_columns": 4 },
+          "propertyOrder": 2
+        },
+        "cooling_method": {
+          "type": "string",
+          "title": "Cooling Method",
+          "description": "Cooling method after hold (e.g., Furnace, Air)",
+          "options": { "grid_columns": 4 },
+          "propertyOrder": 3
+        },
+        "environment": {
+          "type": "string",
+          "title": "Environment",
+          "description": "Atmospheric environment during process (e.g., Ar, N2, Vacuum)",
+          "options": { "grid_columns": 4 },
+          "propertyOrder": 4
+        }
+      }
+    }
+  },
   "properties": {
-    "HeattreatmentID": {
+    "heat_treatment_id": {
       "title": "Heat Treatment ID",
       "description": "Automatically generated, unique identifier for this heat treatment record",
       "notes": "This ID is auto-generated based on heat treatment parameters. You can modify it to correct missing values, but cannot change it to a completely different ID.",
@@ -31,6 +81,7 @@
       "description": "Select one or more IGSNs",
       "notes": "Search and select one or more IGSN identifiers associated with this sample. At least one IGSN must be provided.",
       "minItems": 1,
+      "uniqueItems": true,
       "items": {
         "type": "string",
         "format": "autocomplete",
@@ -47,61 +98,15 @@
       "propertyOrder": 1
     },
     "stress_relief": {
-      "type": "object",
       "title": "Stress Relief",
-      "description": "Stress relief heat treatment parameters",
-      "notes": "Stress relief is a mandatory step. Record the thermal cycle used to reduce residual stresses after fabrication.",
-      "format": "grid-strict",
+      "description": "Stress relief heat treatment parameters. Stress relief is a mandatory step to reduce residual stresses after fabrication.",
+      "notes": "Record the thermal cycle used for stress relief.",
       "propertyOrder": 2,
-      "required": [
-        "time_hr",
-        "temperature_C",
-        "ramp_up_C_per_min",
-        "cool",
-        "environment"
-      ],
-      "properties": {
-        "time_hr": {
-          "type": "number",
-          "title": "Time (hr)",
-          "description": "Duration of stress relief in hours",
-          "examples": [2],
-          "options": { "grid_columns": 4 },
-          "propertyOrder": 0
-        },
-        "temperature_C": {
-          "type": "number",
-          "title": "Temperature (°C)",
-          "description": "Stress relief temperature in degrees Celsius",
-          "examples": [593],
-          "options": { "grid_columns": 4 },
-          "propertyOrder": 1
-        },
-        "ramp_up_C_per_min": {
-          "type": "number",
-          "title": "Ramp Up (°C/min)",
-          "description": "Ramp-up rate in degrees Celsius per minute",
-          "examples": [5],
-          "options": { "grid_columns": 4 },
-          "propertyOrder": 2
-        },
-        "cool": {
-          "type": "string",
-          "title": "Cooling Method",
-          "description": "Cooling method after hold",
-          "examples": ["Furnace"],
-          "options": { "grid_columns": 4 },
-          "propertyOrder": 3
-        },
-        "environment": {
-          "type": "string",
-          "title": "Environment",
-          "description": "Atmospheric environment during stress relief",
-          "examples": ["Ar"],
-          "options": { "grid_columns": 4 },
-          "propertyOrder": 4
+      "allOf": [
+        {
+          "$ref": "#/definitions/heating_process"
         }
-      }
+      ]
     },
     "heat_treatment": {
       "type": "array",
@@ -117,82 +122,41 @@
         "type": "object",
         "title": "Heat Treatment Entry",
         "format": "grid-strict",
-        "required": [
-          "time_hr",
-          "temperature_C",
-          "ramp_up_C_per_min",
-          "cool",
-          "environment"
-        ],
-        "properties": {
-          "time_hr": {
-            "type": "number",
-            "title": "Time (hr)",
-            "description": "Duration of heat treatment in hours",
-            "examples": [2],
-            "options": { "grid_columns": 4 },
-            "propertyOrder": 0
+        "allOf": [
+          {
+            "$ref": "#/definitions/heating_process"
           },
-          "temperature_C": {
-            "type": "number",
-            "title": "Temperature (°C)",
-            "description": "Heat treatment temperature in degrees Celsius",
-            "examples": [820],
-            "options": { "grid_columns": 4 },
-            "propertyOrder": 1
-          },
-          "ramp_up_C_per_min": {
-            "type": "number",
-            "title": "Ramp Up (°C/min)",
-            "description": "Ramp-up rate in degrees Celsius per minute",
-            "examples": [5],
-            "options": { "grid_columns": 4 },
-            "propertyOrder": 2
-          },
-          "cool": {
-            "type": "string",
-            "title": "Cooling Method",
-            "description": "Cooling method after hold",
-            "examples": ["Furnace"],
-            "options": { "grid_columns": 4 },
-            "propertyOrder": 3
-          },
-          "environment": {
-            "type": "string",
-            "title": "Environment",
-            "description": "Atmospheric environment during heat treatment",
-            "examples": ["Ar"],
-            "options": { "grid_columns": 4 },
-            "propertyOrder": 4
-          },
-          "HIP": {
-            "title": "HIP",
-            "description": "Hot Isostatic Pressing — indicate whether the sample was HIPed",
-            "notes": "Select 'HIPed' if Hot Isostatic Pressing was applied. Select 'Not HIPed' if HIP was not performed.",
-            "options": { "grid_columns": 4 },
-            "propertyOrder": 5,
-            "oneOf": [
-              {
-                "title": "Not HIPed",
-                "type": "null"
-              },
-              {
-                "title": "HIPed",
-                "type": "object",
-                "required": ["pressure_MPa"],
-                "properties": {
-                  "pressure_MPa": {
-                    "type": "number",
-                    "title": "Pressure (MPa)",
-                    "description": "HIP pressure in megapascals",
-                    "examples": [100],
-                    "options": { "grid_columns": 4 }
+          {
+            "properties": {
+              "HIP": {
+                "title": "HIP",
+                "description": "Hot Isostatic Pressing — indicate whether the sample was HIPed",
+                "notes": "Select 'HIPed' if Hot Isostatic Pressing was applied. Select 'Not HIPed' if HIP was not performed.",
+                "options": { "grid_columns": 4 },
+                "propertyOrder": 5,
+                "oneOf": [
+                  {
+                    "title": "Not HIPed",
+                    "type": "null"
+                  },
+                  {
+                    "title": "HIPed",
+                    "type": "object",
+                    "required": ["pressure_MPa"],
+                    "properties": {
+                      "pressure_MPa": {
+                        "type": "number",
+                        "title": "Pressure (MPa)",
+                        "description": "HIP pressure in megapascals",
+                        "options": { "grid_columns": 4 }
+                      }
+                    }
                   }
-                }
+                ]
               }
-            ]
+            }
           }
-        }
+        ]
       }
     }
   }

--- a/printer_build_schema.json
+++ b/printer_build_schema.json
@@ -503,7 +503,8 @@
           "title": "Material",
           "type": "string",
           "enum": [
-            "Ti-6Al-4V"
+            "Ti-6Al-4V",
+            "carbon steel",
           ],
           "default": "Ti-6Al-4V",
           "propertyOrder": 0

--- a/raw_powder_schema.json
+++ b/raw_powder_schema.json
@@ -42,6 +42,7 @@
           "AP&C",
           "P&C",
           "Protolabs",
+          "6K Additive",
           "Unknown"
         ]
       },
@@ -55,6 +56,7 @@
         "APC",
         "PC",
         "PRO",
+        "6K",
         "UNK"
       ],
       "propertyOrder": 2


### PR DESCRIPTION
## Description
Add Heat Treatment Record form schema with auto-generated unique identifiers, structured thermal parameter collection, and IGSN integration. Include updates to related printer build and raw powder schemas.

## What's New
- **HeattreatmentID**: Auto-generated identifier from thermal parameters (e.g., `HT_2hr-593C-5rpm-Furnace-Ar_SR`)
- **Stress Relief**: Mandatory thermal cycle with time, temperature, ramp rate, cooling method, and environment
- **Heat Treatment Cycles**: Support for multiple post-stress-relief thermal cycles
- **HIP Tracking**: Optional Hot Isostatic Pressing with pressure recording
- **IGSN Autocomplete**: Link samples via searchable IGSN identifiers
- **Build Plate Materials**: Added carbon steel option to existing Ti-6Al-4V
- **Powder Suppliers**: Added 6K Additive to supplier company list

## Files Changed
- `heat_treatment.json` — Form schema definition
- `heat_treatment.js` — Handlebars helpers and API integration
- `printer_build_schema.json` — Build plate material options expanded
- `raw_powder_schema.json` — Supplier company list updated

## Testing
- Verify HeattreatmentID auto-generation with various parameter combinations
- Test IGSN autocomplete search functionality
- Validate HIP conditional field behavior
- Confirm form submission with multiple heat treatment entries
- Verify build plate material selection includes carbon steel
- Confirm 6K Additive appears in powder supplier selection

@Xarthisius Please review when available.