### PR TITLE
Add pulsed parameters to build form

### DIFF
--- a/build_form.json
+++ b/build_form.json
@@ -66,56 +66,125 @@
         "options": {
           "grid_columns": 12
         },
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["upskin", "downskin", "infill", "contouring"],
-            "description": "Type of build region",
-            "propertyOrder": 1
+        "oneOf": [
+          {
+            "title": "Continuous (Laser Speed)",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["upskin", "downskin", "infill", "contouring"],
+                "description": "Type of build region",
+                "propertyOrder": 1
+              },
+              "laserSpeed": {
+                "type": "number",
+                "title": "Laser Speed",
+                "minimum": 0,
+                "maximum": 10000,
+                "description": "PRC-3-2-9",
+                "propertyOrder": 2,
+                "options": {
+                  "grid_row": 12
+                }
+              },
+              "laserPower": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 370,
+                "description": "PRC-3-2-3",
+                "propertyOrder": 3,
+                "options": {
+                  "grid_row": 12
+                }
+              },
+              "layerThickness": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "PRC-3-2-1",
+                "propertyOrder": 4,
+                "options": {
+                  "grid_row": 12
+                }
+              },
+              "hatchSpacing": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 300,
+                "description": "PRC-3-2-6",
+                "propertyOrder": 5,
+                "options": {
+                  "grid_row": 12
+                }
+              }
+            },
+            "required": ["type", "laserPower", "layerThickness", "hatchSpacing", "laserSpeed"],
+            "additionalProperties": false
           },
-          "laserSpeed": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 10000,
-            "description": "PRC-3-2-9",
-            "propertyOrder": 2,
-            "options": {
-              "grid_row": 12
-            }
-          },
-          "laserPower": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 370,
-            "description": "PRC-3-2-3",
-            "propertyOrder": 3,
-            "options": {
-              "grid_row": 12
-            }
-          },
-          "layerThickness": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 100,
-            "description": "PRC-3-2-1",
-            "propertyOrder": 4,
-            "options": {
-              "grid_row": 12
-            }
-          },
-          "hatchSpacing": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 300,
-            "description": "PRC-3-2-6",
-            "propertyOrder": 5,
-            "options": {
-              "grid_row": 12
-            }
+          {
+            "title": "Pulsed (Distance & Exposure)",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["upskin", "downskin", "infill", "contouring"],
+                "description": "Type of build region",
+                "propertyOrder": 1
+              },
+              "pulseDistance": {
+                "type": "number",
+                "title": "Pulse Distance",
+                "minimum": 0,
+                "description": "Distance between laser pulses",
+                "propertyOrder": 2,
+                "options": {
+                  "grid_row": 12
+                }
+              },
+              "exposureTime": {
+                "type": "number",
+                "title": "Exposure Time",
+                "minimum": 0,
+                "description": "Duration of laser pulse",
+                "propertyOrder": 2.1,
+                "options": {
+                  "grid_row": 12
+                }
+              },
+              "laserPower": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 370,
+                "description": "PRC-3-2-3",
+                "propertyOrder": 3,
+                "options": {
+                  "grid_row": 12
+                }
+              },
+              "layerThickness": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "PRC-3-2-1",
+                "propertyOrder": 4,
+                "options": {
+                  "grid_row": 12
+                }
+              },
+              "hatchSpacing": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 300,
+                "description": "PRC-3-2-6",
+                "propertyOrder": 5,
+                "options": {
+                  "grid_row": 12
+                }
+              }
+            },
+            "required": ["type", "laserPower", "layerThickness", "hatchSpacing", "pulseDistance", "exposureTime"],
+            "additionalProperties": false
           }
-        },
-        "required": ["type", "laserSpeed", "laserPower", "layerThickness", "hatchSpacing"],
-        "additionalProperties": false
+        ]
       }
     }
   },


### PR DESCRIPTION
This PR updates the build form schema to support pulsed laser settings.
It adds two new fields, pulseDistance and exposureTime, under the pulsed parameter option and includes them in required validation.
This allows the form to capture both continuous and pulsed build parameter inputs.