### PR TITLE
Include pulsed parameters in uniqueId generation

### DIFF
--- a/build_form.js
+++ b/build_form.js
@@ -58,13 +58,38 @@ Handlebars.registerHelper('joinarray', function (a, sep, prefix=false) {
     return result;
 });
 
-Handlebars.registerHelper('formatBuildParams', function (params) {
+Handlebars.registerHelper('formatBuildParams', function (params, mode) {
     if (!params || !Array.isArray(params) || params.length === 0) {
         return '';
     }
-    
+
+  const normalize = (value) => (value === undefined || value === null || value === '' ? '' : value);
+  const hasValue = (value) => !(value === undefined || value === null || value === '');
+  const isPulsedMode = mode === 'pulsed' || (mode !== 'continuous' && params.some(p => hasValue(p.pulseDistance) || hasValue(p.exposureTime)));
+
     return params
-        .map(p => `${p.type}:${p.laserSpeed}:${p.laserPower}:${p.layerThickness}:${p.hatchSpacing}`)
+    .map(p => {
+      if (isPulsedMode) {
+        return [
+          p.type,
+          'P',
+          normalize(p.pulseDistance),
+          normalize(p.exposureTime),
+          normalize(p.laserPower),
+          normalize(p.layerThickness),
+          normalize(p.hatchSpacing)
+        ].join(':');
+      }
+
+      return [
+        p.type,
+        'C',
+        normalize(p.laserSpeed),
+        normalize(p.laserPower),
+        normalize(p.layerThickness),
+        normalize(p.hatchSpacing)
+      ].join(':');
+    })
         .join('_');
 });
 
@@ -94,7 +119,7 @@ JSONEditor.defaults.custom_validators.push(function (schema, value, path) {
     return [{
       path: path,
       property: 'type',
-      message: `Duplicate build parameter type(s) not allowed: ${[...duplicates].join(', ')}. 
+      message: `Duplicate build parameter type(s) not allowed: ${[...duplicates].join(', ')}.
 Each type (upskin, downskin, infill, contouring) may only appear once.`
     }];
   }

--- a/build_form.json
+++ b/build_form.json
@@ -44,7 +44,7 @@
       "type": "string",
       "template": "{{formatBuildParams params}}",
       "readOnly": true,
-      "propertyOrder": 2,
+      "propertyOrder": 1,
       "watch": {
         "params": "root.buildParameters"
       },
@@ -56,19 +56,22 @@
       "title": "Build Process Parameters",
       "description": "Laser process parameters for all regions of the build. Each type (upskin, downskin, infill, contouring) can appear only once.",
       "propertyOrder": 3,
-      "type": "array",
-      "minItems": 1,
-      "maxItems": 4,
-      "uniqueItemProperties": ["type"],
-      "items": {
-        "type": "object",
-        "format": "grid",
-        "options": {
-          "grid_columns": 12
-        },
-        "oneOf": [
-          {
-            "title": "Continuous (Laser Speed)",
+      "options": {
+      "grid_columns": 12
+    },
+      "oneOf": [
+        {
+          "title": "Continuous",
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 4,
+          "uniqueItemProperties": ["type"],
+          "items": {
+            "type": "object",
+            "format": "grid",
+            "options": {
+              "grid_columns": 12
+            },
             "properties": {
               "type": {
                 "type": "string",
@@ -118,11 +121,22 @@
                 }
               }
             },
-            "required": ["type", "laserPower", "layerThickness", "hatchSpacing", "laserSpeed"],
+            "required": ["type", "laserSpeed", "laserPower", "layerThickness", "hatchSpacing"],
             "additionalProperties": false
-          },
-          {
-            "title": "Pulsed (Distance & Exposure)",
+          }
+        },
+        {
+          "title": "Pulsed",
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 4,
+          "uniqueItemProperties": ["type"],
+          "items": {
+            "type": "object",
+            "format": "grid",
+            "options": {
+              "grid_columns": 12
+            },
             "properties": {
               "type": {
                 "type": "string",
@@ -181,11 +195,11 @@
                 }
               }
             },
-            "required": ["type", "laserPower", "layerThickness", "hatchSpacing", "pulseDistance", "exposureTime"],
+            "required": ["type", "pulseDistance", "exposureTime", "laserPower", "layerThickness", "hatchSpacing"],
             "additionalProperties": false
           }
-        ]
-      }
+        }
+      ]
     }
   },
   "required": ["lookup", "buildParameters"]


### PR DESCRIPTION
This PR updates Unique ID generation to include pulsed parameters
Now pulsed entries with different values generate different IDs and are no longer treated as duplicates.

@Xarthisius , please review it whenever you have a chance. 