### PR TITLE
Shorten unique id for build form

### DIFF
--- a/build_form.js
+++ b/build_form.js
@@ -63,34 +63,39 @@ Handlebars.registerHelper('formatBuildParams', function (params, mode) {
         return '';
     }
 
-  const normalize = (value) => (value === undefined || value === null || value === '' ? '' : value);
-  const hasValue = (value) => !(value === undefined || value === null || value === '');
-  const isPulsedMode = mode === 'pulsed' || (mode !== 'continuous' && params.some(p => hasValue(p.pulseDistance) || hasValue(p.exposureTime)));
+    const TYPE_ORDER = ['upskin', 'downskin', 'infill', 'contouring'];
+    const TYPE_ABBR = { upskin: 'u', downskin: 'd', infill: 'i', contouring: 'c' };
 
-    return params
-    .map(p => {
-      if (isPulsedMode) {
-        return [
-          p.type,
-          'P',
-          normalize(p.pulseDistance),
-          normalize(p.exposureTime),
-          normalize(p.laserPower),
-          normalize(p.layerThickness),
-          normalize(p.hatchSpacing)
-        ].join(':');
-      }
+    const normalize = (value) => (value === undefined || value === null || value === '' ? '' : value);
+    const hasValue = (value) => !(value === undefined || value === null || value === '');
+    const isPulsedMode = mode === 'pulsed' || (mode !== 'continuous' && params.some(p => hasValue(p.pulseDistance) || hasValue(p.exposureTime)));
 
-      return [
-        p.type,
-        'C',
-        normalize(p.laserSpeed),
-        normalize(p.laserPower),
-        normalize(p.layerThickness),
-        normalize(p.hatchSpacing)
-      ].join(':');
-    })
-        .join('_');
+    // Parameter signature of a region: mode + values, excluding the region type.
+    const signature = (p) => (isPulsedMode
+        ? ['P', normalize(p.pulseDistance), normalize(p.exposureTime), normalize(p.laserPower), normalize(p.layerThickness), normalize(p.hatchSpacing)]
+        : ['C', normalize(p.laserSpeed), normalize(p.laserPower), normalize(p.layerThickness), normalize(p.hatchSpacing)]
+    ).join(':');
+
+    // Sort regions into canonical order so the same set always yields the same ID.
+    const sorted = params.slice().sort((a, b) => TYPE_ORDER.indexOf(a.type) - TYPE_ORDER.indexOf(b.type));
+
+    // Collapse regions sharing identical parameters: group their type initials in
+    // front of a single shared token (e.g. all four identical regions -> "udic:C:...").
+    const groups = [];
+    const bySig = {};
+    sorted.forEach(p => {
+        const sig = signature(p);
+        const abbr = TYPE_ABBR[p.type] || p.type;
+        if (Object.prototype.hasOwnProperty.call(bySig, sig)) {
+            bySig[sig].types += abbr;
+        } else {
+            const group = { types: abbr, sig };
+            bySig[sig] = group;
+            groups.push(group);
+        }
+    });
+
+    return groups.map(g => `${g.types}:${g.sig}`).join('_');
 });
 
 JSONEditor.defaults.custom_validators.push(function (schema, value, path) {

--- a/build_form.json
+++ b/build_form.json
@@ -40,7 +40,7 @@
     },
     "uniqueId": {
       "title": "Unique ID",
-      "description": "Automatically generated, unique identifier for a set of build parameters",
+      "description": "Auto-generated unique ID. Format: 'region initials u/d/i/c, grouped when identical':'C|P':'params', groups joined by '_'. Continuous params = laserSpeed:laserPower:layerThickness:hatchSpacing; Pulsed = pulseDistance:exposureTime:laserPower:layerThickness:hatchSpacing",
       "type": "string",
       "template": "{{formatBuildParams params}}",
       "readOnly": true,


### PR DESCRIPTION
Hashing we did for heat treatment form doesn't really make sense in this case. I tried to save some space by abbreviation and de-duplication instead. The result:

| Old | New |
| --- | --- |
| upskin:C:1000:100:20:20_infill:C:999:99:20:20 | u:C:1000:100:20:20_i:C:999:99:20:20 |
| infill:C:960:285:0.04:0.11 | i:C:960:285:0.04:0.11 |
| infill:C:2100:338:0.04:0.15 | i:C:2100:338:0.04:0.15 |
| infill:C:837:350:0.04:0.132 | i:C:837:350:0.04:0.132 |
| contouring:C:1250:150:30:0_infill:C:1300:350:30:0.14_downskin:C:1200:90:30:0.08 | d:C:1200:90:30:0.08_i:C:1300:350:30:0.14_c:C:1250:150:30:0 |
| infill:C:1300:370:30:140 | i:C:1300:370:30:140 |
| upskin:C:1300:370:30:140_downskin:C:1300:370:30:140_infill:C:1300:370:30:140_contouring:C:1300:370:30:140 | udic:C:1300:370:30:140 |
| infill:C:700:350:40:110 | i:C:700:350:40:110 |
| infill:C:900:350:40:110 | i:C:900:350:40:110 |
| infill:C:1000:350:40:110 | i:C:1000:350:40:110 |
| infill:C:1050:350:40:110 | i:C:1050:350:40:110 |
| infill:C:1100:350:40:110 | i:C:1100:350:40:110 |
| infill:C:1150:350:40:110 | i:C:1150:350:40:110 |
| infill:C:1200:350:40:110 | i:C:1200:350:40:110 |
| infill:C:1250:350:40:110 | i:C:1250:350:40:110 |
| infill:C:1300:350:40:110 | i:C:1300:350:40:110 |
| infill:C:1400:350:40:110 | i:C:1400:350:40:110 |
| infill:P:22:20:370:30:100 | i:P:22:20:370:30:100 |
| infill:P:25:20:370:30:100 | i:P:25:20:370:30:100 |
| infill:P:30:20:370:30:100 | i:P:30:20:370:30:100 |
| infill:P:35:20:370:30:100 | i:P:35:20:370:30:100 |
| infill:P:39:20:370:30:100 | i:P:39:20:370:30:100 |
| infill:P:16:20:280:30:100 | i:P:16:20:280:30:100 |
| infill:P:19:20:280:30:100 | i:P:19:20:280:30:100 |
| infill:P:24:20:280:30:100 | i:P:24:20:280:30:100 |
| infill:P:28:20:280:30:100 | i:P:28:20:280:30:100 |
| infill:P:33:20:280:30:100 | i:P:33:20:280:30:100 |