### PR TITLE
Add Square prisms to printer build schema

### DIFF
--- a/printer_build_schema.json
+++ b/printer_build_schema.json
@@ -293,7 +293,8 @@
             "FCG",
             "MC",
             "RBF",
-            "C"
+            "C",
+            "SQP"
           ],
           "options": {
             "grid_columns": 6,
@@ -306,7 +307,8 @@
               "FCG (fatigue crack growth)",
               "MC (Microstructure cubes)",
               "RBF (Rotating beam fatigue)",
-              "C (Composition)"
+              "C (Composition)",
+              "SQP (Square Prisms)"
             ]
           },
           "propertyOrder": 0,


### PR DESCRIPTION
This PR adds Square Prisms as a new geometry option in the printer build schema for Alloy 718 Build 2 sample uploads.


